### PR TITLE
[Bug] Add width to fix style element

### DIFF
--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -188,6 +188,7 @@ body, html {
     height: 1.5em;
     opacity: .5;
     font-size: 1.4em;
+    width:100%;
 }
 
 .hr-text::before {


### PR DESCRIPTION
This PR:
* Fixes a small inline style element in the login card

BEFORE:

<img width="367" alt="screen shot 2019-03-06 at 11 51 26 am" src="https://user-images.githubusercontent.com/1534575/53898679-8a8d2c80-4006-11e9-861d-2b93b0536521.png">

AFTER:

<img width="355" alt="screen shot 2019-03-06 at 11 51 52 am" src="https://user-images.githubusercontent.com/1534575/53898724-a395dd80-4006-11e9-8a72-d3e25857dbc3.png">

